### PR TITLE
GN-4660: Resize column based on sibling column width #1103

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -45,7 +45,8 @@
   <p>The table:</p>
   <table>
     <tr>
-      <th colspan="3" data-colwidth="100,0,0">Wide header</th>
+<!--      <th colspan="3" data-colwidth="100,0,0">Wide header</th>-->
+      <th colspan="3">Wide header</th>
     </tr>
     <tr>
       <td>One</td>

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest --environment happy-dom",
     "build": "tsup",
+    "prepare": "tsup",
     "watch": "tsup --watch",
     "build_readme": "builddocs --name tables --format markdown --main src/README.md src/*.js > README.md",
     "format": "prettier --write .",


### PR DESCRIPTION
### Overview

Implements column resizing which is similar to how desktop Word and Google Docs does it. 

* Main work is done in fork of `prosemirror-tables`, see the PR here - https://github.com/lblod/prosemirror-tables/pull/1
* Changes in `editor` are mainly to accommodate the changed plugin - https://github.com/lblod/ember-rdfa-editor/pull/1103

##### connected issues and PRs:


<!-- Link to PRs that are related (and in what way) -->


### Setup

1. Checkout https://github.com/lblod/ember-rdfa-editor/pull/1103
2. `npm i`, might have to `rm -rf node_modules` first, so the `prosemirror-tables` is installed from GitHub.

### How to test/reproduce

1. `npm run start` 
2. Insert table
3. Try to resize columns.


https://github.com/lblod/ember-rdfa-editor/assets/769698/66834ab0-4fd9-4698-9e42-1f9899f1e1bc




### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations
