### PR TITLE
Assign columns widths explicitly when column is added/deleted

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -44,20 +44,23 @@
   <h2>Example content</h2>
   <p>The table:</p>
   <table>
-    <tr>
-      <!--      <th colspan="3" data-colwidth="100,0,0">Wide header</th>-->
-      <th colspan="3">Wide header</th>
-    </tr>
-    <tr>
-      <td>One</td>
-      <td>Two</td>
-      <td>Three</td>
-    </tr>
-    <tr>
-      <td>Four</td>
-      <td>Five</td>
-      <td>Six</td>
-    </tr>
+    <colgroup>
+      <col />
+      <col />
+      <col />
+    </colgroup>
+    <tbody>
+      <tr>
+        <td data-colwidth="20"><p>One</p></td>
+        <td data-colwidth="40"><p>Two</p></td>
+        <td data-colwidth="40"><p>Three</p></td>
+      </tr>
+      <tr>
+        <td data-colwidth="20"><p>Four</p></td>
+        <td data-colwidth="40"><p>Five</p></td>
+        <td data-colwidth="40"><p>Six</p></td>
+      </tr>
+    </tbody>
   </table>
 </div>
 

--- a/src/tablemap.ts
+++ b/src/tablemap.ts
@@ -16,6 +16,16 @@ import { CellAttrs } from './util';
  */
 export type ColWidths = number[];
 
+export const isColWidths = (value: unknown): value is ColWidths => {
+  if (!Array.isArray(value)) return false;
+
+  for (const item of value) {
+    if (typeof item !== 'number') return false;
+  }
+
+  return true;
+};
+
 /**
  * @public
  */


### PR DESCRIPTION
### Adding column

When `addColumn` command is performed while a cell is focused, the width of the cell that is focused will be reduced by 2, and the new column will take that width

### Deleting column

Width of the deleted column will be added to the adjacent column

### Demo

https://github.com/lblod/prosemirror-tables/assets/769698/85ffa7a4-2bb7-4f0b-9711-f03b04e87c2e

### Considerations

Needs to be checked in Editor